### PR TITLE
Fix travis build error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .vim-flavor/
-Gemfile.lock
 VimFlavor.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ install: |
   export VIM_PLUGIN_DIR=$HOME/.vim/plugin
   mkdir -p $VIM_PLUGIN_DIR
   git clone https://github.com/tkhoa2711/vim-togglenumber.git $VIM_PLUGIN_DIR/vim-togglenumber
+  gem install bundler
+  gem update --system
   bundle install --jobs=3 --retry=3
 script: rake ci
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 sudo: required
 rvm:
-  - 2.0.0
+  - 2.6.5
 os:
   - linux
   - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 sudo: required
 rvm:
-  - 2.6.5
+  - 2.3.8
 os:
   - linux
   - osx
@@ -20,12 +20,12 @@ before_install: |
       make && sudo make install
       popd
   fi
+  gem update --system
+  gem install bundler
 install: |
   export VIM_PLUGIN_DIR=$HOME/.vim/plugin
   mkdir -p $VIM_PLUGIN_DIR
   git clone https://github.com/tkhoa2711/vim-togglenumber.git $VIM_PLUGIN_DIR/vim-togglenumber
-  gem install bundler
-  gem update --system
   bundle install --jobs=3 --retry=3
 script: rake ci
 notifications:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,17 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    parslet (1.8.2)
+    thor (0.20.3)
+    vim-flavor (1.1.5)
+      parslet (~> 1.0)
+      thor (~> 0.14)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  vim-flavor (~> 1.1)
+
+BUNDLED WITH
+   2.0.1


### PR DESCRIPTION
Fix Travis build error on Mac when running `bundle install`, example output: https://travis-ci.org/tkhoa2711/vim-togglenumber/jobs/528826391

```
/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems.rb:241:in `bin_path': can't find gem bundler (>= 0.a) (Gem::GemNotFoundException)
	from /usr/local/bin/bundle:22:in `<main>'
```